### PR TITLE
Optimisations to accessibility themes and better slidedeck renders

### DIFF
--- a/custom/formatter.py
+++ b/custom/formatter.py
@@ -1,8 +1,10 @@
-from os.path import abspath
+import logging
+from os.path import abspath, relpath
 from pathlib import Path
 
 
 def slideshow(source, language, css_class, options, md, classes=None, id_value='', attrs=None, **kwargs):
+    _ignored = [language, css_class, options, md, classes, id_value, attrs, kwargs]
     try:
         output = ""
 
@@ -25,7 +27,21 @@ def slideshow(source, language, css_class, options, md, classes=None, id_value='
         for index, slide in enumerate(loaded_slides):
             output += f'<div class="slide slide-{index}">{slide}</div>'
 
-        return f'<div class="slide-deck">{output}<div class="controls"></div></div>'
+        return f'<div class="slide-deck">{output}</div>'
     except BaseException as error:
-        print(error)
-        return 'Could not render slideshow!'
+        message = f'Something went wrong: {error}'
+
+        if hasattr(error, 'filename'):
+            message = f'{relpath(error.filename)} does not exist'
+
+        raise_warning(message)
+
+        return f'<div class="admonition danger">' \
+               f'<p class="admonition-title">Error: {message}</p>' \
+               f'<p><pre><code>{source}</code></pre></p>' \
+               f'</div>'
+
+
+def raise_warning(message):
+    logger = logging.getLogger("mkdocs.plugins")
+    logger.warning(f'[custom.formatter.slideshow] {message}')

--- a/overrides/assets/stylesheets/accessibility.css
+++ b/overrides/assets/stylesheets/accessibility.css
@@ -71,3 +71,28 @@ html.theme-greyscale {
 html.theme-yellow-on-black {
     filter: invert(1) sepia(1) saturate(2.5) hue-rotate(8deg);
 }
+
+html.theme-yellow-on-black [data-md-toggle=search]:checked ~ .md-header .md-search__overlay {
+    background-color: rgba(255, 255, 255, 0.8);
+}
+
+html.theme-yellow-on-black [data-md-toggle=search]:checked ~ .md-header .md-search__output {
+    box-shadow: var(--md-shadow-z1);
+    opacity: 1;
+}
+
+html.theme-yellow-on-black .focus-visible,
+html.theme-yellow-on-black .md-search-result__link:focus,
+html.theme-yellow-on-black .md-search-result__link:hover,
+html.theme-yellow-on-black .md-search-result__more:focus,
+html.theme-yellow-on-black .md-search-result__more:hover,
+html.theme-yellow-on-black .focus-visible *,
+html.theme-yellow-on-black .md-search-result__link:focus *,
+html.theme-yellow-on-black .md-search-result__link:hover *,
+html.theme-yellow-on-black .md-search-result__more:focus *,
+html.theme-yellow-on-black .md-search-result__more:hover *,
+html.theme-yellow-on-black .md-search-result__more > summary:focus > div,
+html.theme-yellow-on-black .md-search-result__more > summary:hover > div {
+    background-color: #0027ffc7;
+    color: white;
+}

--- a/overrides/assets/stylesheets/accessibility.css
+++ b/overrides/assets/stylesheets/accessibility.css
@@ -65,7 +65,7 @@
 }
 
 html.theme-greyscale {
-    filter: grayscale(100%);
+    filter: saturate(2.5) grayscale(100%);
 }
 
 html.theme-yellow-on-black {

--- a/overrides/assets/stylesheets/accessibility.css
+++ b/overrides/assets/stylesheets/accessibility.css
@@ -69,5 +69,5 @@ html.theme-greyscale {
 }
 
 html.theme-yellow-on-black {
-    filter: grayscale(80%) invert(1) sepia(1) saturate(2.5) hue-rotate(11deg);
+    filter: invert(1) sepia(1) saturate(2.5) hue-rotate(8deg);
 }

--- a/overrides/assets/stylesheets/accessibility.css
+++ b/overrides/assets/stylesheets/accessibility.css
@@ -64,10 +64,10 @@
     min-height: 500px !important;
 }
 
-:root.theme-greyscale {
+html.theme-greyscale {
     filter: grayscale(100%);
 }
 
-:root.theme-yellow-on-black {
+html.theme-yellow-on-black {
     filter: grayscale(80%) invert(1) sepia(1) saturate(2.5) hue-rotate(11deg);
 }

--- a/overrides/assets/stylesheets/theme.css
+++ b/overrides/assets/stylesheets/theme.css
@@ -88,3 +88,11 @@ blockquote:before {
     color: var(--md-primary-bg-color) !important;
     opacity: 1;
 }
+
+.md-header {
+    position: inherit !important;
+}
+
+.md-sidebar {
+    top: 0 !important;
+}

--- a/overrides/assets/stylesheets/theme.css
+++ b/overrides/assets/stylesheets/theme.css
@@ -96,3 +96,7 @@ blockquote:before {
 .md-sidebar {
     top: 0 !important;
 }
+
+.md-top.md-icon {
+    top: 15px !important;
+}

--- a/overrides/partials/javascripts/announce.html
+++ b/overrides/partials/javascripts/announce.html
@@ -1,4 +1,0 @@
-{#-
-  This file was automatically generated - do not edit
--#}
-<script>var content,el=document.querySelector("[data-md-component=announce]");el&&(content=el.querySelector(".md-typeset"),__md_hash(content.innerHTML)===__md_get("__announce")&&(el.hidden=!0))</script>

--- a/overrides/partials/javascripts/consent.html
+++ b/overrides/partials/javascripts/consent.html
@@ -1,4 +1,0 @@
-{#-
-  This file was automatically generated - do not edit
--#}
-<script>var consent=__md_get("__consent");if(consent)for(var input of document.forms.consent.elements)input.name&&(input.checked=consent[input.name]||!1);else"file:"!==location.protocol&&setTimeout(function(){document.querySelector("[data-md-component=consent]").hidden=!1},250);var action,form=document.forms.consent;for(action of["submit","reset"])form.addEventListener(action,function(e){if(e.preventDefault(),"reset"===e.type)for(var n of document.forms.consent.elements)n.name&&(n.checked=!1);__md_set("__consent",Object.fromEntries(Array.from(new FormData(form).keys()).map(function(e){return[e,!0]}))),location.hash="",location.reload()})</script>


### PR DESCRIPTION
# Optimisations to accessibility themes and better slidedeck renders

## Why? What? How?

* The header now does not take up a large chunk of the screen on zoom
* Search overlay looks better in yellow on black
* Remove some customised partials
* Raise an error when the custom formatter fails

## Checklist

- [x] This PR **does not** alter any page content.
- [ ] This PR introduces a new page.
  - [ ] I have ensured that there are links from other pages to this new content.
- [ ] This PR updates existing pages.
- [ ] I have previewed my changes using [StackEdit](https://stackedit.io/app), and they match my expectations.
- [ ] I have checked that any abbreviations used match up with [built-in abbreviations](https://github.com/CPS-Innovation/digital-sop/tree/main/snippets/abbreviations.md).
