### PR TITLE
Fix Collapsible Navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.top
     - navigation.tracking
     - navigation.indexes
+    - toc.integrate
 
 plugins:
   - git-revision-date-localized:

--- a/overrides/assets/stylesheets/theme.css
+++ b/overrides/assets/stylesheets/theme.css
@@ -97,12 +97,14 @@ blockquote:before {
     opacity: 1;
 }
 
-.md-header {
-    position: inherit !important;
-}
+@media screen and (min-width: 76.1875em) {
+    .md-header {
+        position: inherit !important;
+    }
 
-.md-sidebar {
-    top: 0 !important;
+    .md-sidebar {
+        top: 0 !important;
+    }
 }
 
 .md-top.md-icon {

--- a/overrides/partials/nav-item.html
+++ b/overrides/partials/nav-item.html
@@ -1,4 +1,3 @@
-
 {% macro render(nav_item, path, level) %}
 
 
@@ -26,15 +25,8 @@
       {% if expanded and not checked %}
         {% set indeterminate = "md-toggle--indeterminate" %}
       {% endif %}
-
-      <input
-        class="md-nav__toggle md-toggle {{ indeterminate }}"
-        type="checkbox"
-        id="{{ path }}_h"
-        {{ checked }}
-      />
-
-      {% set indexes = [nav_item] if nav_item.url else [] %}
+      <input class="md-nav__toggle md-toggle {{ indeterminate }}" type="checkbox" id="{{ path }}" {{ checked }}>
+      {% set indexes = [] %}
       {% if "navigation.indexes" in features %}
         {% for nav_item in nav_item.children %}
           {% if nav_item.is_index and not index is defined %}
@@ -44,12 +36,7 @@
       {% endif %}
 
       {% if not indexes %}
-        <label
-          class="md-nav__link"
-          for="{{ path }}_h"
-          id="{{ path }}_label"
-          tabindex="0"
-        >
+        <label class="md-nav__link" for="{{ path }}" id="{{ path }}_label" tabindex="0">
           {{ nav_item.title }}
           <span class="md-nav__icon md-icon"></span>
         </label>
@@ -58,23 +45,27 @@
         {% set index = indexes | first %}
         {% set class = "md-nav__link--active" if index == page %}
         <div class="md-nav__link md-nav__link--index {{ class }}">
-          <a href="{{ index.url | url }}">{{ index.title }}</a>
-
-          {% if nav_item.children %}
-            <label for="{{ path }}_h">
+          <a href="{{ index.url | url }}">
+            {{ index.title }}
+          </a>
+          {% if nav_item.children | length > 1 %}
+            <label for="{{ path }}">
               <span style="display: none">Expand</span>
               <span class="md-nav__icon md-icon"></span>
             </label>
           {% endif %}
         </div>
       {% endif %}
-
-      <nav
-        class="md-nav"
-        data-md-level="{{ level }}"
-        aria-label="{{ nav_item.title }}"
-        aria-expanded="{{ nav_item.active | tojson }}"
-      >
+      <nav class="md-nav" data-md-level="{{ level }}" aria-labelledby="{{ path }}" aria-expanded="{{ nav_item.active | tojson }}">
+        <label class="md-nav__title" for="{{ path }}">
+          {% if indexes %}
+            {% set index = indexes | first %}
+            {{ index.title }}
+          {% else %}
+            {{ nav_item.title }}
+          {% endif %}
+          <span class="md-nav__icon md-icon"></span>
+        </label>
         <ul class="md-nav__list" data-md-scrollfix>
 
           {% for nav_item in nav_item.children %}
@@ -90,16 +81,18 @@
   {% elif nav_item == page %}
     <li class="{{ class }}">
       {% set toc = page.toc %}
-
+      <input class="md-nav__toggle md-toggle" type="checkbox" id="__toc">
       {% set first = toc | first %}
       {% if first and first.level == 1 %}
         {% set toc = first.children %}
       {% endif %}
-
-      <a
-        href="{{ nav_item.url | url }}"
-        class="md-nav__link md-nav__link--active"
-      >
+      {% if toc %}
+        <label class="md-nav__link md-nav__link--active" for="__toc">
+          {{ nav_item.title }}
+          <span class="md-nav__icon md-icon"></span>
+        </label>
+      {% endif %}
+      <a href="{{ nav_item.url | url }}" class="md-nav__link md-nav__link--active">
         {{ nav_item.title }}
       </a>
 

--- a/overrides/partials/nav-item.html
+++ b/overrides/partials/nav-item.html
@@ -102,6 +102,10 @@
       >
         {{ nav_item.title }}
       </a>
+
+      {% if toc and "toc.integrate" in features %}
+        {% include "partials/toc.html" %}
+      {% endif %}
     </li>
 
   {% else %}

--- a/overrides/partials/toc.html
+++ b/overrides/partials/toc.html
@@ -12,10 +12,10 @@
     {% set toc = first.children %}
   {% endif %}
   {% if toc %}
-    <span class="md-nav__title">
+    <label class="md-nav__title" for="__toc">
       <span class="md-nav__icon md-icon"></span>
       {{ title }}
-    </span>
+    </label>
     <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
       {% for toc_item in toc %}
         {% include "partials/toc-item.html" %}


### PR DESCRIPTION
# Fix Collapsible Navigation

## Why? What? How?

* Fix collapsible navigation in mobile views.
* Some duplication of labels, but only one label set is visible on the page at a time.

## Checklist

- [x] This PR **does not** alter any page content.
- [ ] This PR introduces a new page.
  - [ ] I have ensured that there are links from other pages to this new content.
- [ ] This PR updates existing pages.
- [ ] I have previewed my changes using [StackEdit](https://stackedit.io/app), and they match my expectations.
- [ ] I have checked that any abbreviations used match up with [built-in abbreviations](https://github.com/CPS-Innovation/digital-sop/tree/main/snippets/abbreviations.md).
- Accessibility
  - Instructional
    - [ ] I have added content that tells a user how to complete a task without telling them to click a button based on 
          its shape or similar visual direction.
  - Text
    - [ ] Page headings are not duplicated on the same page.
  - Images
    - [ ] Embedded images have alt text present.
    - [ ] Embedded images that include text have that text included in the alt text.
    - [ ] Embedded images have a contrast ratio of at least 4.5:1.
    - [ ] Embedded images have content that cannot be presented in text alone.
  - Audio
    - [ ] Embedded audio clips have a transcript included.
  - Video
    - [ ] Embedded videos have a transcript included.
    - [ ] Embedded videos have synchronised subtitles / closed captions included.
    - [ ] Embedded audio clips have sign language version included where audio exists.
